### PR TITLE
설정 화면 UI 구현 (음성 안내 / 백그라운드 동작 / 테마 모드) 및 routes 추가

### DIFF
--- a/shelter/frontend/lib/main.dart
+++ b/shelter/frontend/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart'; // Flutter의 기본 UI 패키지를 가져옴
+import 'package:shelter/screens/settings/SettingsMainScreens.dart';
 import 'screens/test.dart';
+import 'routes/AppRoutes.dart';
 
 void main() {
   // 앱의 시작점 (main 함수)
@@ -7,8 +9,7 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  // 앱 전체의 루트 위젯 (StatelessWidget: 상태를 가지지 않는 위젯)
-  const MyApp({super.key}); // 생성자
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -16,12 +17,11 @@ class MyApp extends StatelessWidget {
       title: '대피소 앱', // 앱의 기본 제목 (iOS나 일부 안드로이드에서 사용됨)
       theme: ThemeData(
         fontFamily: 'NotoSansKR', // 앱 전체에서 사용할 기본 글꼴
-        textTheme: const TextTheme(
-          bodyMedium: TextStyle(fontSize: 14), // 기본 텍스트 크기 설정
-          bodyLarge: TextStyle(fontWeight: FontWeight.bold), // 큰 텍스트는 굵게 표시
-        ),
       ),
-      home: const TestScreen(), // 앱 실행 시 처음 보여줄 화면
+
+      initialRoute: AppRoutes.settings,
+      routes: AppRoutes.routes,
+      home: const SettingsMainScreen(), // 앱 실행 시 처음 보여줄 화면
       debugShowCheckedModeBanner: false, // 오른쪽 상단 디버그 배너 제거
     );
   }

--- a/shelter/frontend/lib/routes/AppRoutes.dart
+++ b/shelter/frontend/lib/routes/AppRoutes.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import '../screens/settings/SettingsMainScreens.dart';
+import '../screens/settings/VoiceGuideScreen.dart';
+import '../screens/settings/BackgroundActivityScreen.dart';
+import '../screens/settings/ThemeModeScreen.dart';
+
+class AppRoutes {
+  static const String settings = '/settings';
+  static const String voiceGuide = '/voiceGuide';
+  static const String backgroundActivity = '/backgroundActivity';
+  static const String themeMode = '/themeMode';
+
+  static Map<String, WidgetBuilder> routes = {
+    settings: (context) => const SettingsMainScreen(),
+    voiceGuide: (context) => const VoiceGuideScreen(),
+    backgroundActivity: (context) => const BackgroundActivityScreen(),
+    themeMode: (context) => const ThemeModeScreen(),
+  };
+}

--- a/shelter/frontend/lib/screens/settings/BackgroundActivityScreen.dart
+++ b/shelter/frontend/lib/screens/settings/BackgroundActivityScreen.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import '../../theme/color.dart';
+import '../../theme/typography.dart';
+import '../../component/settingItem/ToggleSwitch.dart';
+
+class BackgroundActivityScreen extends StatefulWidget {
+  const BackgroundActivityScreen({super.key});
+
+  @override
+  State<BackgroundActivityScreen> createState() =>
+      _BackgroundActivityScreenState();
+}
+
+class _BackgroundActivityScreenState extends State<BackgroundActivityScreen> {
+  bool isBackgroundEnabled = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.white,
+      appBar: AppBar(
+        backgroundColor: AppColors.white,
+        elevation: 0,
+        iconTheme: const IconThemeData(color: AppColors.black),
+        title: const Text('백그라운드 동작', style: AppTextStyles.title),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 28),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text('앱을 닫아도 네비게이션 계속', style: AppTextStyles.subtitle),
+                ToggleSwitch(
+                  isOn: isBackgroundEnabled,
+                  onChanged:
+                      (value) => setState(() {
+                        isBackgroundEnabled = value;
+                      }),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+
+            const Text(
+              '백그라운드 동작을 활성화하면 앱을 닫아도 음성 안내가 계속됩니다.\n'
+              '배터리 소모가 증가하므로 사용 상황에 따라 설정해 주세요.',
+              style: AppTextStyles.captionGray,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/shelter/frontend/lib/screens/settings/SettingsMainScreens.dart
+++ b/shelter/frontend/lib/screens/settings/SettingsMainScreens.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:shelter/routes/AppRoutes.dart';
+import '../../component/list/SettingsNavItem.dart';
+import '../../component/list/ConfigItem.dart';
+import '../../theme/color.dart';
+import '../../theme/typography.dart';
+
+class SettingsMainScreen extends StatelessWidget {
+  const SettingsMainScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.white,
+      appBar: AppBar(
+        backgroundColor: AppColors.white,
+        title: const Text('설정', style: AppTextStyles.title),
+        elevation: 0,
+        iconTheme: const IconThemeData(color: AppColors.black),
+      ),
+      body: Column(
+        children: [
+          const Divider(height: 1, thickness: 1, color: AppColors.lightGray),
+
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              children: [
+                const SizedBox(height: 8),
+
+                SettingsNavItem(
+                  label: '음성 안내',
+                  onTap:
+                      () => Navigator.pushNamed(context, AppRoutes.voiceGuide),
+                ),
+                SettingsNavItem(
+                  label: '백그라운드 동작',
+                  onTap:
+                      () => Navigator.pushNamed(
+                        context,
+                        AppRoutes.backgroundActivity,
+                      ),
+                ),
+                SettingsNavItem(
+                  label: '테마 모드',
+                  onTap:
+                      () => Navigator.pushNamed(context, AppRoutes.themeMode),
+                ),
+
+                const SizedBox(height: 8),
+
+                const ConfigItem(label: 'GPS', value: 'ON'),
+                const ConfigItem(label: '앱 정보', value: 'version 1.0'),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/shelter/frontend/lib/screens/settings/ThemeModeScreen.dart
+++ b/shelter/frontend/lib/screens/settings/ThemeModeScreen.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import '../../theme/color.dart';
+import '../../theme/typography.dart';
+
+class ThemeModeScreen extends StatefulWidget {
+  const ThemeModeScreen({super.key});
+
+  @override
+  State<ThemeModeScreen> createState() => _ThemeModeScreenState();
+}
+
+class _ThemeModeScreenState extends State<ThemeModeScreen> {
+  int selectedIndex = 2; // 기본값: 자동 전환
+
+  final List<String> modes = ['라이트 모드', '다크 모드', '자동 전환'];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.white,
+      appBar: AppBar(
+        backgroundColor: AppColors.white,
+        elevation: 0,
+        iconTheme: const IconThemeData(color: AppColors.black),
+        title: const Text('테마 모드', style: AppTextStyles.title),
+      ),
+      body: ListView.separated(
+        itemCount: modes.length,
+        separatorBuilder:
+            (context, index) => const Divider(
+              height: 1,
+              thickness: 1,
+              color: AppColors.lightGray,
+            ),
+        itemBuilder: (context, index) {
+          final isSelected = index == selectedIndex;
+
+          return ListTile(
+            contentPadding: const EdgeInsets.symmetric(horizontal: 20),
+            title: Text(modes[index], style: AppTextStyles.subtitle),
+            trailing:
+                isSelected
+                    ? const Icon(Icons.check, color: AppColors.blue)
+                    : null,
+            onTap: () {
+              setState(() {
+                selectedIndex = index;
+              });
+              // 여기서 실제 테마 변경 처리도 나중에 연결 가능
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/shelter/frontend/lib/screens/settings/VoiceGuideScreen.dart
+++ b/shelter/frontend/lib/screens/settings/VoiceGuideScreen.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import '../../theme/color.dart';
+import '../../theme/typography.dart';
+import '../../component/settingItem/ToggleSwitch.dart';
+import '../../component/settingItem/VolumeSlider.dart';
+
+class VoiceGuideScreen extends StatefulWidget {
+  const VoiceGuideScreen({super.key});
+
+  @override
+  State<VoiceGuideScreen> createState() => _VoiceGuideScreenState();
+}
+
+class _VoiceGuideScreenState extends State<VoiceGuideScreen> {
+  bool isVoiceGuideOn = true;
+  bool isMutedModeOn = false;
+  double volume = 0.5;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.white,
+      appBar: AppBar(
+        backgroundColor: AppColors.white,
+        elevation: 0,
+        iconTheme: const IconThemeData(color: AppColors.black),
+        title: const Text('음성 안내', style: AppTextStyles.title),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text('음성 안내', style: AppTextStyles.subtitle),
+                ToggleSwitch(
+                  isOn: isVoiceGuideOn,
+                  onChanged: (value) => setState(() => isVoiceGuideOn = value),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Expanded(
+                  child: Text(
+                    '음소거 시에도 음성 경보를 켜기',
+                    style: AppTextStyles.subtitle,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                ToggleSwitch(
+                  isOn: isMutedModeOn,
+                  onChanged: (value) => setState(() => isMutedModeOn = value),
+                ),
+              ],
+            ),
+            const SizedBox(height: 32),
+
+            const Text('음량 조절', style: AppTextStyles.subtitle),
+            const SizedBox(height: 12),
+
+            VolumeSlider(
+              value: volume,
+              onChanged: (value) => setState(() => volume = value),
+              enabled: isVoiceGuideOn,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/shelter/frontend/pubspec.lock
+++ b/shelter/frontend/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   fixnum:
     dependency: transitive
     description:
@@ -196,10 +196,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -401,10 +401,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "14.3.1"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
## 작업 내용
- 설정 메인 화면 UI 구성
- 음성 안내 화면 (토글, 볼륨 슬라이더)
- 백그라운드 동작 토글 화면
- 테마 모드 선택 화면 (라이트/다크/자동)

## 주요 변경 파일
- `SettingsMainScreen.dart`
- `VoiceGuideScreen.dart`
- `BackgroundActivityScreen.dart`
- `ThemeModeScreen.dart`
- `AppRoutes.dart`
- `main.dart` (테스트 해보기 위해 변경함)

## 커밋 내역
-  설정 메인 화면 UI 구성
-  음성 안내 화면 UI 구현
-  백그라운드 동작 UI 구현
-  테마 모드 선택 화면 구현
-  설정 관련 라우트 추가

## 현재 상황
- 현재 UI만 구현 해 놓은 상태로 추후 home 화면의 구성 및 기능 구현이 완료된 후에 기능적인 부분을 완성할 예정

## 관련 이슈
Closes #50