### PR TITLE
BottomSheet 상세 모드 높이 및 UI 조정Fix app design sheet components

### DIFF
--- a/shelter/frontend/lib/component/bottomSheet/ShelterBottomSheet.dart
+++ b/shelter/frontend/lib/component/bottomSheet/ShelterBottomSheet.dart
@@ -17,13 +17,14 @@ class ShelterBottomSheet extends StatelessWidget {
   Widget build(BuildContext context) {
     final initialSize = mode == SheetMode.list ? 0.5 : 0.4;
     final snapSizes = mode == SheetMode.list
-        ? [0.085, 0.5, 0.95]
-        : [0.085, 0.35, 0.95];
+        ? [0.06, 0.5, 0.95]
+        : [0.06, 0.4];
+    final maxSize = mode == SheetMode.list ? 0.95 : initialSize;
 
     return DraggableScrollableSheet(
       initialChildSize: initialSize,
-      minChildSize: 0.085,
-      maxChildSize: 0.95,
+      minChildSize: 0.06,
+      maxChildSize: maxSize,
       snap: true,
       snapSizes: snapSizes,
       builder: (context, scrollController) {

--- a/shelter/frontend/pubspec.yaml
+++ b/shelter/frontend/pubspec.yaml
@@ -62,7 +62,7 @@ flutter:
   assets:
     - shelter_db/shelters.db
     - lib/assets/user_locations/user_locations.json
-    - assets/mbtiles/korea_z8_17.mbtiles
+    # - assets/mbtiles/korea_z8_17.mbtiles
     # - assets/kr-map.mbtiles
     # - assets/osm/8/
     # - assets/osm/8/216/


### PR DESCRIPTION
이슈에 올라온 내용에 따라 BottomSheet의 상세 모드 최대 높이를 수정했습니다.
확인 부탁합니다.

변경내용 :detailSheet 높이를 초기값과 동일한 높이로 변경
Github Issue : #92 
