### PR TITLE
BottomSheet UI 개선 및 상세 화면 전용 NavButton 문구 적용

### DIFF
--- a/shelter/frontend/lib/component/bottomSheet/ShelterBottomSheet.dart
+++ b/shelter/frontend/lib/component/bottomSheet/ShelterBottomSheet.dart
@@ -17,9 +17,10 @@ class ShelterBottomSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final initialSize = mode == SheetMode.list ? 0.4 : 0.4;
-    final snapSizes = mode == SheetMode.list ? [0.06, 0.4, 0.95] : [0.06, 0.4];
+    final initialSize = mode == SheetMode.list ? 0.4 : 0.35;
+    final snapSizes = mode == SheetMode.list ? [0.06, 0.4, 0.95] : [0.06, 0.35];
     final maxSize = mode == SheetMode.list ? 0.95 : initialSize;
+    final paddingSize = mode == SheetMode.list ? EdgeInsets.only(top: 5, bottom: 30) : EdgeInsets.only(top: 5, bottom: 45);
 
     return DraggableScrollableSheet(
       controller: controller,
@@ -60,7 +61,7 @@ class ShelterBottomSheet extends StatelessWidget {
                 child: SingleChildScrollView(
                   controller: scrollController,
                   child: Padding(
-                    padding: const EdgeInsets.only(top: 5, bottom: 30),
+                    padding: paddingSize,
                     child: child,
                   ),
                 ),

--- a/shelter/frontend/lib/component/bottomSheet/ShelterBottomSheet.dart
+++ b/shelter/frontend/lib/component/bottomSheet/ShelterBottomSheet.dart
@@ -18,8 +18,8 @@ class ShelterBottomSheet extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final initialSize = mode == SheetMode.list ? 0.4 : 0.35;
-    final snapSizes = mode == SheetMode.list ? [0.06, 0.4, 0.95] : [0.06, 0.35];
-    final maxSize = mode == SheetMode.list ? 0.95 : initialSize;
+    final snapSizes = mode == SheetMode.list ? [0.06, 0.4, 0.86] : [0.06, 0.35];
+    final maxSize = mode == SheetMode.list ? 0.86 : initialSize;
     final paddingSize = mode == SheetMode.list ? EdgeInsets.only(top: 5, bottom: 30) : EdgeInsets.only(top: 5, bottom: 45);
 
     return DraggableScrollableSheet(


### PR DESCRIPTION
### 변경 내용
• BottomSheet (리스트 모드) 최대 높이 조정
• BottomSheet (상세 모드) 초기 높이 축소
• NavButtonText 외부 설정 지원
-> ShelterListItem 컴포넌트에 navButtonText 파라미터를 추가하여 버튼 텍스트를 화면별로 외부에서 지정 가능하도록 구조 개선
※ ShelterDetailView에서도 navButtonText를 외부로부터 받아 ShelterListItem에 전달

Issue #143